### PR TITLE
Using Properties for Getter and Setter, CamelCase for naming convention

### DIFF
--- a/AdvancedTimer/AdvancedTimer.Forms.Plugin.Abstractions/IAdvancedTimer.cs
+++ b/AdvancedTimer/AdvancedTimer.Forms.Plugin.Abstractions/IAdvancedTimer.cs
@@ -10,31 +10,27 @@ namespace AdvancedTimer.Forms.Plugin.Abstractions
         /// <summary>
         /// Used for initializing timer and options
         /// </summary>
-        void initTimer(int interval, EventHandler e, bool autoReset);
+        void InitTimer(int interval, EventHandler e, bool autoReset);
 
         /// <summary>
         /// Used for starting timer
         /// </summary>
-        void startTimer();
+        void StartTimer();
 
         /// <summary>
         /// Used for stopping timer
         /// </summary>
-        void stopTimer();
+        void StopTimer();
 
         /// <summary>
         /// Used for checking timer status
         /// </summary>
-        bool isTimerEnabled();
+		bool IsTimerEnabled { get; }
 
         /// <summary>
         /// Used for checking timer interval
         /// </summary>
-        int getInterval();
+		int Interval { get; set; }
 
-        /// <summary>
-        /// Used for setting timer interval
-        /// </summary>
-        void setInterval(int interval);
     }
 }

--- a/AdvancedTimer/AdvancedTimer.Forms.Plugin.Android/AdvancedTimerImplementation.cs
+++ b/AdvancedTimer/AdvancedTimer.Forms.Plugin.Android/AdvancedTimerImplementation.cs
@@ -24,7 +24,7 @@ namespace AdvancedTimer.Forms.Plugin.Droid
         /// <summary>
         /// Used for initializing timer and options
         /// </summary>
-        public void initTimer(int interval, EventHandler e, bool autoReset)
+        public void InitTimer(int interval, EventHandler e, bool autoReset)
         {
             if (this.timer == null)
             {
@@ -41,7 +41,7 @@ namespace AdvancedTimer.Forms.Plugin.Droid
         /// <summary>
         /// Used for starting timer
         /// </summary>
-        public void startTimer()
+        public void StartTimer()
         {
             if (this.timer != null)
             {
@@ -59,7 +59,7 @@ namespace AdvancedTimer.Forms.Plugin.Droid
         /// <summary>
         /// Used for stopping timer
         /// </summary>
-        public void stopTimer()
+        public void StopTimer()
         {
             if (this.timer != null)
             {
@@ -77,26 +77,29 @@ namespace AdvancedTimer.Forms.Plugin.Droid
         /// <summary>
         /// Used for checking timer status
         /// </summary>
-        public bool isTimerEnabled()
+        public bool IsTimerEnabled
         {
-            return this.timer.Enabled;
+			get 
+			{
+				return this.timer.Enabled;
+			}
         }
 
         /// <summary>
         /// Used for checking timer interval
         /// </summary>
-        public int getInterval()
+        public int Interval
         {
-            return this.interval;
+			get 
+			{
+				return this.interval;
+			}
+			set 
+			{
+				this.interval = value;
+				this.timer.Interval = value;
+			}
         }
 
-        /// <summary>
-        /// Used for setting timer interval
-        /// </summary>
-        public void setInterval(int interval)
-        { 
-            this.interval = interval;
-            this.timer.Interval = interval;
-        }
     }
 }

--- a/AdvancedTimer/AdvancedTimer.Forms.Plugin.WindowsPhone/AdvancedTimerImplementation.cs
+++ b/AdvancedTimer/AdvancedTimer.Forms.Plugin.WindowsPhone/AdvancedTimerImplementation.cs
@@ -24,7 +24,7 @@ namespace AdvancedTimer.Forms.Plugin.WindowsPhone
         /// <summary>
         /// Used for initializing timer and options
         /// </summary>
-        public void initTimer(int interval, EventHandler e, bool autoReset)
+        public void InitTimer(int interval, EventHandler e, bool autoReset)
         {
             if (this.timer == null)
             {
@@ -46,7 +46,7 @@ namespace AdvancedTimer.Forms.Plugin.WindowsPhone
         /// <summary>
         /// Used for starting timer
         /// </summary>
-        public void startTimer()
+        public void StartTimer()
         {
             if (this.timer != null)
             {
@@ -64,7 +64,7 @@ namespace AdvancedTimer.Forms.Plugin.WindowsPhone
         /// <summary>
         /// Used for stopping timer
         /// </summary>
-        public void stopTimer()
+        public void StopTimer()
         {
             if (this.timer != null)
             {
@@ -82,26 +82,29 @@ namespace AdvancedTimer.Forms.Plugin.WindowsPhone
         /// <summary>
         /// Used for checking timer status
         /// </summary>
-        public bool isTimerEnabled()
+        public bool IsTimerEnabled
         {
-            return this.timer.IsEnabled;
+			get 
+			{
+				return this.timer.IsEnabled;
+			}
         }
 
         /// <summary>
         /// Used for checking timer interval
         /// </summary>
-        public int getInterval()
+        public int Interval
         {
-            return this.interval;
+			get 
+			{
+				return this.interval;
+			}
+			set 
+			{
+				this.interval = value;
+				this.timer.Interval = TimeSpan.FromMilliseconds(value);
+			}
         }
 
-        /// <summary>
-        /// Used for setting timer interval
-        /// </summary>
-        public void setInterval(int interval)
-        {
-            this.interval = interval;
-            this.timer.Interval = TimeSpan.FromMilliseconds(interval);
-        }
     }
 }

--- a/AdvancedTimer/AdvancedTimer.Forms.Plugin.iOS/AdvancedTimerImplementation.cs
+++ b/AdvancedTimer/AdvancedTimer.Forms.Plugin.iOS/AdvancedTimerImplementation.cs
@@ -24,7 +24,7 @@ namespace AdvancedTimer.Forms.Plugin.iOS
         /// <summary>
         /// Used for initializing timer and options
         /// </summary>
-        public void initTimer(int interval, EventHandler e, bool autoReset)
+        public void InitTimer(int interval, EventHandler e, bool autoReset)
         {
             if (this.timer == null)
             {
@@ -41,7 +41,7 @@ namespace AdvancedTimer.Forms.Plugin.iOS
         /// <summary>
         /// Used for starting timer
         /// </summary>
-        public void startTimer()
+        public void StartTimer()
         {
             if (this.timer != null)
             {
@@ -59,7 +59,7 @@ namespace AdvancedTimer.Forms.Plugin.iOS
         /// <summary>
         /// Used for stopping timer
         /// </summary>
-        public void stopTimer()
+        public void StopTimer()
         {
             if (this.timer != null)
             {
@@ -77,26 +77,29 @@ namespace AdvancedTimer.Forms.Plugin.iOS
         /// <summary>
         /// Used for checking timer status
         /// </summary>
-        public bool isTimerEnabled()
+        public bool IsTimerEnabled
         {
-            return this.timer.Enabled;
+			get 
+			{
+				return this.timer.Enabled;
+			}
         }
 
         /// <summary>
         /// Used for checking timer interval
         /// </summary>
-        public int getInterval()
+        public int Interval
         {
-            return this.interval;
+			get 
+			{
+				return this.interval;
+			}
+			set 
+			{
+				this.interval = value;
+				this.timer.Interval = value;
+			}
         }
 
-        /// <summary>
-        /// Used for setting timer interval
-        /// </summary>
-        public void setInterval(int interval)
-        {
-            this.interval = interval;
-            this.timer.Interval = interval;
-        }
     }
 }


### PR DESCRIPTION
Hello. Thanks for the great AdvancedTimer project. Looks cool. I just want to help with changing the name convention since we're using C# as programming language.

Your new Methods will look like this:
timer.InitTimer(3000, timerElapsed, true);
timer.StartTimer();
timer.StopTimer();
var interval = timer.Interval;
timer.Interval = 5000;
timer.IsTimerEnabled;
